### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/laittis/wobbly-life-editor/security/code-scanning/5](https://github.com/laittis/wobbly-life-editor/security/code-scanning/5)

To fix this issue, explicitly set the `permissions` key at the top level of the workflow. This will apply to all jobs (test, build, security), ensuring they only receive the minimal necessary permissions. Each job in this CI pipeline clones the repository (`actions/checkout`), which requires only `contents: read`. None of the jobs appear to publish artifacts, interact with issues, pull requests, or require any write privileges. Therefore, the safest and most correct fix is to add `permissions: contents: read` after the workflow name and before `on:`. No further changes are needed to steps or jobs.

**How to implement:**

- In `.github/workflows/ci.yml`, insert the following lines after line 1 (`name: CI`):
  ```
  permissions:
    contents: read
  ```
- This applies to the whole workflow. No changes to imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
