### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,6 @@
 name: Release
+permissions:
+  contents: write
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/laittis/wobbly-life-editor/security/code-scanning/3](https://github.com/laittis/wobbly-life-editor/security/code-scanning/3)

To fix the issue, explicitly specify the `permissions` key at the root of the workflow or in each job, granting only the minimum permissions required. In this workflow, the jobs interact with releases by creating them and uploading assets. These actions require `contents: write` permission (read-only is insufficient for release creation and asset upload). If any job needs more or less permission, you can scope the permissions to individual jobs. However, a root-level `permissions:` block is a suitable starting point unless finer granularity is required. The change should be placed after the `name:` field and before `on:` (or as the first entry under each job if scoping per-job). You do not need to add or change any imports in this case.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
