### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 
+permissions:
+  contents: read
+
 on:
   push:
     tags:
@@ -11,6 +14,8 @@ env:
 jobs:
   create-release:
     name: Create Release
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}


### PR DESCRIPTION
Potential fix for [https://github.com/laittis/wobbly-life-editor/security/code-scanning/1](https://github.com/laittis/wobbly-life-editor/security/code-scanning/1)

To fix this problem, add a `permissions` block to restrict the GITHUB_TOKEN permissions to exactly what is needed for the workflow jobs. For a release workflow, the "create-release" job needs write permissions for `contents` (to create a release) and possibly for reading code (though read is implied for most cases). For the "build-release" job, only read permissions for `contents` are needed to checkout code. The most robust minimal fix is to set `permissions` at the workflow root (to apply sensible defaults to all jobs), and override with more permissive settings as needed per job. 

The best way is:
- Add (at the top level, after `name:` and before/on the same level as `jobs:`) a `permissions:` block, setting `contents: read`.
- For the `create-release` job (lines 12-33), add a job-level `permissions:` block explicitly giving `contents: write` (since it creates a release). If other steps in the job require additional write access (e.g., to pull-requests), that should be added, but based on current steps just `contents: write` is sufficient.

No additional dependencies are required; these are all YAML settings for GitHub Actions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
