### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/laittis/wobbly-life-editor/security/code-scanning/2](https://github.com/laittis/wobbly-life-editor/security/code-scanning/2)

To address this issue, you should add a root-level `permissions:` block to the workflow file (`.github/workflows/ci.yml`). This should be placed directly under the workflow name (and potentially the `on:` block), and before any `jobs:` key. The recommended minimal permission for this workflow is `contents: read`, which restricts the `GITHUB_TOKEN` to merely fetching repository contents. This change will apply to all jobs in the workflow unless overridden by per-job settings. No existing functionality will be affected because none of the jobs require additional permissions. No imports or other changes are needed; simply amend the YAML workflow as described.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
